### PR TITLE
feat(dictionaryListAPI Ego Update):

### DIFF
--- a/src/main/java/com/example/limbusDeckMaker/controller/DictionaryController.java
+++ b/src/main/java/com/example/limbusDeckMaker/controller/DictionaryController.java
@@ -44,9 +44,14 @@ public class DictionaryController {
     public ResponseEntity<List<EgoListInfoDto>> searchEgosByCriteria(
         @RequestParam(value = "id", required = false) Long id,
         @RequestParam(value = "season", required = false) Integer season,
-        @RequestParam(value = "grade", required = false) String grade) {
+        @RequestParam(value = "grade", required = false) String grade,
+        @RequestParam(value = "keyword", required = false) List<String> keywords,
+        @RequestParam(value = "resources", required = false) List<String> resources,
+        @RequestParam(value = "types", required = false) List<String> types,
+        @RequestParam(value = "minWeight", required = false) Integer minWeight,
+        @RequestParam(value = "maxWeight", required = false) Integer maxWeight) {
 
-        List<EgoListInfoDto> results = egoService.getEgoByCriteria(id, season, grade);
+        List<EgoListInfoDto> results = egoService.getEgoByCriteria(id, season, grade, keywords, resources, types, minWeight, maxWeight);
         if(results.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
@@ -57,7 +62,8 @@ public class DictionaryController {
     public ResponseEntity<List<IdentityListInfoDto>> searchIdentitiesByCriteria(
         @RequestParam(value = "id", required = false) Long id,
         @RequestParam(value = "season", required = false) Integer season,
-        @RequestParam(value = "grade", required = false) Integer grade) {
+        @RequestParam(value = "grade", required = false) Integer grade
+        ) {
 
         List<IdentityListInfoDto> results = identityService.getIdentityByCriteria(id, season, grade);
         if(results.isEmpty()) {

--- a/src/main/java/com/example/limbusDeckMaker/dto/response/EgoContext.java
+++ b/src/main/java/com/example/limbusDeckMaker/dto/response/EgoContext.java
@@ -1,0 +1,20 @@
+package com.example.limbusDeckMaker.dto.response;
+
+import com.example.limbusDeckMaker.domain.Ego;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class EgoContext {
+    private final Ego ego;
+    private final List<String> resources;
+    private final List<String> types;
+    private final Integer minWeight;
+    private final Integer maxWeight;
+
+}

--- a/src/main/java/com/example/limbusDeckMaker/dto/response/EgoListInfoDto.java
+++ b/src/main/java/com/example/limbusDeckMaker/dto/response/EgoListInfoDto.java
@@ -1,11 +1,5 @@
 package com.example.limbusDeckMaker.dto.response;
 
-import static com.example.limbusDeckMaker.service.mapper.EgoListInfoMapper.findUseResources;
-import static com.example.limbusDeckMaker.service.mapper.EgoListInfoMapper.findCorType;
-import static com.example.limbusDeckMaker.service.mapper.EgoListInfoMapper.findMaxWeight;
-import static com.example.limbusDeckMaker.service.mapper.EgoListInfoMapper.findMinWeight;
-import static com.example.limbusDeckMaker.service.mapper.EgoListInfoMapper.findSkillType;
-
 import com.example.limbusDeckMaker.domain.Ego;
 import java.util.List;
 import lombok.Builder;
@@ -28,12 +22,11 @@ public class EgoListInfoDto {
     private List<String> keyword;
 
     private List<String> resources;
-    private String skillType;
-    private String corType;
+    private List<String> types;
     private Integer minWeight;
     private Integer maxWeight;
 
-    public static EgoListInfoDto toDto(Ego ego){
+    public static EgoListInfoDto toDto(Ego ego, EgoContext egoContext){
         return EgoListInfoDto.builder()
             .id(ego.getId())
             .character(ego.getSinner().getName())
@@ -43,11 +36,10 @@ public class EgoListInfoDto {
             .zoomImage(ego.getZoomImage())
             .grade(ego.getGrade())
             .keyword(ego.getKeyword())
-            .resources(findUseResources(ego))
-            .skillType(findSkillType(ego))
-            .corType(findCorType(ego))
-            .minWeight(findMinWeight(ego))
-            .maxWeight(findMaxWeight(ego))
+            .resources(egoContext.getResources())
+            .types(egoContext.getTypes())
+            .minWeight(egoContext.getMinWeight())
+            .maxWeight(egoContext.getMaxWeight())
             .build();
     }
 

--- a/src/main/java/com/example/limbusDeckMaker/service/EgoService.java
+++ b/src/main/java/com/example/limbusDeckMaker/service/EgoService.java
@@ -1,6 +1,9 @@
 package com.example.limbusDeckMaker.service;
 
+import static com.example.limbusDeckMaker.service.mapper.EgoListInfoMapper.*;
+
 import com.example.limbusDeckMaker.domain.Ego;
+import com.example.limbusDeckMaker.dto.response.EgoContext;
 import com.example.limbusDeckMaker.dto.response.EgoDetailInfoDto;
 import com.example.limbusDeckMaker.dto.response.EgoListInfoDto;
 import com.example.limbusDeckMaker.repository.EgoRepository;
@@ -25,9 +28,11 @@ public class EgoService {
             .map(EgoDetailInfoDto::toDto);
     }
 
-    public List<EgoListInfoDto> getEgoByCriteria(Long sinnerId, Integer season, String grade) {
-        Specification<Ego> spec = Specification.where(null);
+    public List<EgoListInfoDto> getEgoByCriteria(Long sinnerId, Integer season, String grade,
+        List<String> keywords, List<String> resources, List<String> types, Integer minWeight,
+        Integer maxWeight) {
 
+        Specification<Ego> spec = Specification.where(null);
         if (sinnerId != null) {
             spec = spec.and(EgoSpecification.hasSinnerId(sinnerId));
         }
@@ -39,10 +44,49 @@ public class EgoService {
         }
 
         List<Ego> egos = egoRepository.findAll(spec);
+        List<EgoContext> egoContexts = egos.stream()
+            .map(ego -> new EgoContext(ego,
+                findUseResources(ego),
+                findUseTypes(ego),
+                findMinWeight(ego),
+                findMaxWeight(ego)))
+            .toList();
 
-        return egos.stream()
-            .map(EgoListInfoDto::toDto)
+        return egoContexts.stream()
+            .filter(context -> matchesKeywords(context, keywords))
+            .filter(context -> matchesResources(context, resources))
+            .filter(context -> matchesTypes(context, types))
+            .filter(context -> matchesWeight(context, minWeight, maxWeight))
+            .map(context -> EgoListInfoDto.toDto(context.getEgo(), context))
             .collect(Collectors.toList());
+
+    }
+
+    private boolean matchesKeywords(EgoContext context, List<String> keywords) {
+        if (keywords == null || keywords.isEmpty()) {
+            return true;
+        }
+        return keywords.stream().allMatch(keyword -> context.getEgo().getKeyword().contains(keyword));
+    }
+
+    private boolean matchesResources(EgoContext context, List<String> resources) {
+        if (resources == null || resources.isEmpty()) {
+            return true;
+        }
+        return resources.stream().allMatch(resource -> context.getResources().contains(resource));
+    }
+
+    private boolean matchesTypes(EgoContext context, List<String> types) {
+        if (types == null || types.isEmpty()) {
+            return true;
+        }
+        return types.stream().allMatch(type -> context.getTypes().contains(type));
+    }
+
+    private boolean matchesWeight(EgoContext context, Integer minWeight, Integer maxWeight) {
+        boolean matchesMin = minWeight == null || context.getMinWeight().equals(minWeight);
+        boolean matchesMax = maxWeight == null || context.getMaxWeight().equals(maxWeight);
+        return matchesMin && matchesMax;
     }
 
 }

--- a/src/main/java/com/example/limbusDeckMaker/service/mapper/EgoListInfoMapper.java
+++ b/src/main/java/com/example/limbusDeckMaker/service/mapper/EgoListInfoMapper.java
@@ -4,7 +4,10 @@ import com.example.limbusDeckMaker.domain.Ego;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class EgoListInfoMapper {
@@ -37,24 +40,20 @@ public class EgoListInfoMapper {
         return usingResources;
     }
 
-    public static String findSkillType(Ego ego) {
-        return ego.getEgoSkills().stream()
-            .filter(egoSkill -> egoSkill.getConstrueLevel() == 4)
-            .map(egoSkill -> egoSkill.getSkill().getSkillInfo().getAtkType())
-            .findFirst()
-            .orElse(null);
-    }
+    public static List<String> findUseTypes(Ego ego){
+        Set<String> uniqueTypes = new HashSet<>();
 
-    public static String findCorType(Ego ego) {
-        if (ego.getEgoCorSkills() == null){
-            return null;
-        }
+        Stream.concat(
+                ego.getEgoSkills().stream().filter(s -> s.getConstrueLevel() == 4)
+                    .map(egoSkill -> egoSkill.getSkill().getSkillInfo().getAtkType()),
+                ego.getEgoCorSkills().stream().filter(s -> s.getConstrueLevel() == 4)
+                    .map(corrosionSkill -> corrosionSkill.getCorSkill().getCorrosionSkillInfo().getAtkType())
+            )
+            .forEach(uniqueTypes::add);
 
-        return ego.getEgoCorSkills().stream()
-            .filter(egoCorSkill -> egoCorSkill.getConstrueLevel() == 4)
-            .map(egoCorSkill -> egoCorSkill.getCorSkill().getCorrosionSkillInfo().getAtkType())
-            .findFirst()
-            .orElse(null);
+        List<String> usingTypes = new ArrayList<>(uniqueTypes);
+        usingTypes.sort(Comparator.naturalOrder());
+        return usingTypes;
     }
 
     public static Integer findMinWeight(Ego ego) {


### PR DESCRIPTION
쿼리 파라미터 추가
minWeight, maxWeight : 일치하는 경우
keyword, resources, types : 모두 존재하는 경우

keyword, resources, type, weight에 경우 쿼리파라미터 매칭 시
캐시 형태로 저장했다가 API response시 활용하여 중복 실행 방지

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
기존의 백에서 쿼리파라미터로 3가지 정보(sinnerId, season, grade)만 처리하던 것을 
작업의 효율성을 위해 작업을 통해 모든 정보에 대해서 처리하도록 변경

<!---- Resolves: #(Isuue Number) -->
#42 
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
